### PR TITLE
Bump to Kodi 19.3, Ubuntu 21.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 ARG UBUNTU_RELEASE=impish
 FROM ubuntu:$UBUNTU_RELEASE
 
-ARG KODI_VERSION=19.3
+ARG KODI_VERSION=19.4
 
 # https://github.com/ehough/docker-nfs-server/pull/3#issuecomment-387880692
 ARG DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,19 +18,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-FROM ubuntu:focal
+ARG UBUNTU_RELEASE=impish
+FROM ubuntu:$UBUNTU_RELEASE
 
-ARG KODI_VERSION=19.0
+ARG KODI_VERSION=19.3
 
 # https://github.com/ehough/docker-nfs-server/pull/3#issuecomment-387880692
 ARG DEBIAN_FRONTEND=noninteractive
 
 # install the team-xbmc ppa
-RUN apt-get update                                                        && \
-    apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:team-xbmc/ppa                                  && \
-    apt-get -y purge openssl software-properties-common                   && \
-    apt-get -y --purge autoremove                                         && \
+RUN apt-get update                                                                  && \
+    apt-get install -y --no-install-recommends gpg-agent software-properties-common && \
+    add-apt-repository ppa:team-xbmc/ppa                                            && \
+    apt-get -y purge openssl gpg-agent software-properties-common                   && \
+    apt-get -y --purge autoremove                                                   && \
     rm -rf /var/lib/apt/lists/*
 
 ARG KODI_EXTRA_PACKAGES=
@@ -51,7 +52,7 @@ ARG KODI_EXTRA_PACKAGES=
 RUN packages="                                               \
                                                              \
     ca-certificates                                          \
-    kodi=2:${KODI_VERSION}+*                                 \
+    kodi=6:${KODI_VERSION}+*                                 \
     kodi-eventclients-kodi-send                              \
     kodi-game-libretro                                       \
     kodi-game-libretro-beetle-pce-fast                       \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,64 +46,15 @@ ARG KODI_EXTRA_PACKAGES=
 #  - pulseaudio                   in case the user prefers PulseAudio instead of ALSA
 #  - tzdata                       necessary for timezone selection
 #  - va-driver-all                the full suite of drivers for the Video Acceleration API (VA API)
-#  - kodi-game-libretro-*         Libretro cores (DEPRECATED: WILL BE REMOVED IN VERSION 4 OF THIS IMAGE)
-#  - kodi-pvr-*                   PVR add-ons (DEPRECATED: WILL BE REMOVED IN VERSION 4 OF THIS IMAGE)
-#  - kodi-screensaver-*           additional screensavers (DEPRECATED: WILL BE REMOVED IN VERSION 4 OF THIS IMAGE)
 RUN packages="                                               \
                                                              \
     ca-certificates                                          \
     kodi=6:${KODI_VERSION}+*                                 \
     kodi-eventclients-kodi-send                              \
-    kodi-game-libretro                                       \
-    kodi-game-libretro-beetle-pce-fast                       \
-    kodi-game-libretro-beetle-vb                             \
-    kodi-game-libretro-beetle-wswan                          \
-    kodi-game-libretro-bsnes-mercury-accuracy                \
-    kodi-game-libretro-bsnes-mercury-balanced                \
-    kodi-game-libretro-bsnes-mercury-performance             \
-    kodi-game-libretro-desmume                               \
-    kodi-game-libretro-fbalpha2012                           \
-    kodi-game-libretro-fuse                                  \
-    kodi-game-libretro-gambatte                              \
-    kodi-game-libretro-prboom                                \
-    kodi-game-libretro-stella                                \
-    kodi-game-libretro-tgbdual                               \
-    kodi-game-libretro-vba-next                              \
-    kodi-game-libretro-virtualjaguar                         \
     kodi-inputstream-adaptive                                \
     kodi-inputstream-rtmp                                    \
     kodi-peripheral-joystick                                 \
     kodi-peripheral-xarcade                                  \
-    kodi-pvr-argustv                                         \
-    kodi-pvr-dvblink                                         \
-    kodi-pvr-dvbviewer                                       \
-    kodi-pvr-filmon                                          \
-    kodi-pvr-hdhomerun                                       \
-    kodi-pvr-hts                                             \
-    kodi-pvr-iptvsimple                                      \
-    kodi-pvr-mediaportal-tvserver                            \
-    kodi-pvr-mythtv                                          \
-    kodi-pvr-nextpvr                                         \
-    kodi-pvr-njoy                                            \
-    kodi-pvr-octonet                                         \
-    kodi-pvr-pctv                                            \
-    kodi-pvr-sledovanitv-cz                                  \
-    kodi-pvr-stalker                                         \
-    kodi-pvr-teleboy                                         \
-    kodi-pvr-vbox                                            \
-    kodi-pvr-vdr-vnsi                                        \
-    kodi-pvr-vuplus                                          \
-    kodi-pvr-wmc                                             \
-    kodi-pvr-zattoo                                          \
-    kodi-screensaver-asteroids                               \
-    kodi-screensaver-asterwave                               \
-    kodi-screensaver-biogenesis                              \
-    kodi-screensaver-cpblobs                                 \
-    kodi-screensaver-greynetic                               \
-    kodi-screensaver-matrixtrails                            \
-    kodi-screensaver-pingpong                                \
-    kodi-screensaver-pyro                                    \
-    kodi-screensaver-stars                                   \
     locales                                                  \
     pulseaudio                                               \
     tzdata                                                   \


### PR DESCRIPTION
This PR bumps Kodi + Ubuntu to the latest versions. Note that manual installation of `gpg-agent` is now required for `add-apt-repository` to work.

I've also cleaned up the deprecated packages, as this seemed like an appropriate time to remove them - let me know if you'd like me to remove that commit.